### PR TITLE
Fix date formatters

### DIFF
--- a/SQLiteStatement.swift
+++ b/SQLiteStatement.swift
@@ -14,7 +14,9 @@ extension NSDate {
     
     func toString() -> String! {
         
-        var dateFormatter = NSDateFormatter()
+        let dateFormatter = NSDateFormatter()
+        dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        dateFormatter.timeZone = NSTimeZone(forSecondsFromGMT: 0)
         dateFormatter.dateFormat = isoStringFormat
         
         return dateFormatter.stringFromDate(self)
@@ -25,7 +27,9 @@ extension String {
     
     func toDate() -> NSDate! {
         
-        var dateFormatter = NSDateFormatter()
+        let dateFormatter = NSDateFormatter()
+        dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        dateFormatter.timeZone = NSTimeZone(forSecondsFromGMT: 0)
         dateFormatter.dateFormat = isoStringFormat
         
         return dateFormatter.dateFromString(self)


### PR DESCRIPTION
The date formatters were storing date with `Z` (i.e. Zulu, i.e. GMT/UTC), but the actual date string was not GMT, but rather the device's current timezone. For example, it's 10:01am in New York right now, and the previous formatter would have written `2015-02-03T10:01:00Z`, whereas the appropriate ISO 8601 / RFC 3339  time string is `2015-02-03T15:01:00Z`. Bottom line, the code neglected to set the time zone for the formatter to GMT/UTC. The problem is that if the device ever changed timezones (and anyone who lives near time zone border, such as Chicago, will see this a lot), all the times stored in the database will be off.

The solution is to specify the formatter's timezone to correspond to the use of `Z` in the output string.

---

There is a more subtle problem here, too. If the user's device was not using Gregorian calendar, the year would be incorrect. See [Technical Q&A1480](https://developer.apple.com/library/ios/qa/qa1480/_index.html). Now, admittedly, it's unlikely that the user is likely to change their device to and from gregorian calendar frequently, but you really must isolate your code from these issues by ensuring that the date formatter explicitly sets the `locale`, ensuring that dates are stored and retrieved (and sorted) in a consistent manner.